### PR TITLE
Tell It's All Text! that file textarea is markdown.

### DIFF
--- a/qa-markdown-editor.php
+++ b/qa-markdown-editor.php
@@ -24,7 +24,7 @@ class qa_markdown_editor
 	function get_field(&$qa_content, $content, $format, $fieldname, $rows, $autofocus)
 	{
 		$html = '<div id="wmd-button-bar-'.$fieldname.'" class="wmd-button-bar"></div>' . "\n";
-		$html .= '<textarea name="'.$fieldname.'" id="wmd-input-'.$fieldname.'" class="wmd-input">'.$content.'</textarea>' . "\n";
+		$html .= '<textarea name="'.$fieldname.'" id="wmd-input-'.$fieldname.'" itsalltext-extension=".md" class="wmd-input">'.$content.'</textarea>' . "\n";
 		$html .= '<h3>Preview</h3>' . "\n";
 		$html .= '<div id="wmd-preview-'.$fieldname.'" class="wmd-preview"></div>' . "\n";
 


### PR DESCRIPTION
The [It's All Text!](https://github.com/docwhat/itsalltext) Firefox extension
lets you edit textareas in your favorite desktop editor.

This change tells IAT that it should use an extension of `.md` when creating
the file for the desktop editor; which allows syntax highlighting and
indenting to work in most editors.

FYI: I'm the author of IAT.  I'm using this plugin for Q2A and
like it very much.  This change makes it even more useful for
me and my users. :-)
