### PR TITLE
added an admin option to configure the editor for third party templates

### DIFF
--- a/qa-markdown-editor.php
+++ b/qa-markdown-editor.php
@@ -10,7 +10,7 @@ class qa_markdown_editor
 	private $cssopt = 'markdown_editor_css';
 	private $convopt = 'markdown_comment';
 	private $hljsopt = 'markdown_highlightjs';
-	private $allowed_template_opt = 'markdown_editor_allowed_template';
+	private $allowed_templates_opt = 'markdown_editor_allowed_templates';
 
 	public function load_module($directory, $urltoroot)
 	{
@@ -71,8 +71,8 @@ class qa_markdown_editor
 			qa_opt($this->convopt, $convert);
 			$convert = qa_post_text('md_highlightjs') ? '1' : '0';
 			qa_opt($this->hljsopt, $convert);
-			$allowed_template = qa_post_text('allowed_template');
-			qa_opt($this->allowed_template_opt , $allowed_template);
+			$allowed_templates = qa_post_text('allowed_templates');
+			qa_opt($this->allowed_templates_opt , $allowed_templates);
 
 			$saved_msg = qa_lang_html('admin/options_saved');
 		}
@@ -106,10 +106,10 @@ class qa_markdown_editor
 				),
 				'allowed_template' => array(
 					'type' => 'text',
-					'label' => qa_lang_html('markdown/admin_allowed_template'),
-					'tags' => 'NAME="allowed_template"',
-					'value' => qa_opt($this->allowed_template_opt),
-					'note' => qa_lang_html('markdown/admin_allowed_template_note'),
+					'label' => qa_lang_html('markdown/admin_allowed_templates'),
+					'tags' => 'NAME="allowed_templates"',
+					'value' => qa_opt($this->allowed_templates_opt),
+					'note' => qa_lang_html('markdown/admin_allowed_templates_note'),
 				),
 			),
 
@@ -126,7 +126,7 @@ class qa_markdown_editor
 	function option_default($option)
 	{
 		switch ($option) {
-			case $this->allowed_template_opt :
+			case $this->allowed_templates_opt :
 				return 'ask,question';
 				break;
 			default:

--- a/qa-markdown-editor.php
+++ b/qa-markdown-editor.php
@@ -10,6 +10,7 @@ class qa_markdown_editor
 	private $cssopt = 'markdown_editor_css';
 	private $convopt = 'markdown_comment';
 	private $hljsopt = 'markdown_highlightjs';
+	private $allowed_template_opt = 'markdown_editor_allowed_template';
 
 	public function load_module($directory, $urltoroot)
 	{
@@ -70,6 +71,8 @@ class qa_markdown_editor
 			qa_opt($this->convopt, $convert);
 			$convert = qa_post_text('md_highlightjs') ? '1' : '0';
 			qa_opt($this->hljsopt, $convert);
+			$allowed_template = qa_post_text('allowed_template');
+			qa_opt($this->allowed_template_opt , $allowed_template);
 
 			$saved_msg = qa_lang_html('admin/options_saved');
 		}
@@ -101,6 +104,13 @@ class qa_markdown_editor
 					'value' => qa_opt($this->hljsopt) === '1',
 					'note' => qa_lang_html('markdown/admin_syntax_note'),
 				),
+				'allowed_template' => array(
+					'type' => 'text',
+					'label' => qa_lang_html('markdown/admin_allowed_template'),
+					'tags' => 'NAME="allowed_template"',
+					'value' => qa_opt($this->allowed_template_opt),
+					'note' => qa_lang_html('markdown/admin_allowed_template_note'),
+				),
 			),
 
 			'buttons' => array(
@@ -113,6 +123,17 @@ class qa_markdown_editor
 		);
 	}
 
+	function option_default($option)
+	{
+		switch ($option) {
+			case $this->allowed_template_opt :
+				return 'ask,question';
+				break;
+			default:
+				return null;
+				break;
+		}
+	}
 
 	// copy of qa-base.php > qa_post_text, with trim() function removed.
 	private function _my_qa_post_text($field)

--- a/qa-md-lang-default.php
+++ b/qa-md-lang-default.php
@@ -14,4 +14,6 @@ return array(
 	'admin_comments_note' => 'Sets a post as plaintext when converting answers to comments.',
 	'admin_syntax' => 'Use syntax highlighting',
 	'admin_syntax_note' => 'Integrates highlight.js for code blocks.',
+	'admin_allowed_template' => 'Allowed templates for markdown editor',
+	'admin_allowed_template_note' => 'Templates separated by comma',
 );

--- a/qa-md-lang-default.php
+++ b/qa-md-lang-default.php
@@ -14,6 +14,6 @@ return array(
 	'admin_comments_note' => 'Sets a post as plaintext when converting answers to comments.',
 	'admin_syntax' => 'Use syntax highlighting',
 	'admin_syntax_note' => 'Integrates highlight.js for code blocks.',
-	'admin_allowed_template' => 'Allowed templates for markdown editor',
-	'admin_allowed_template_note' => 'Templates separated by comma',
+	'admin_allowed_templates' => 'Allowed templates for markdown editor',
+	'admin_allowed_templates_note' => 'Templates separated by comma',
 );

--- a/qa-md-layer.php
+++ b/qa-md-layer.php
@@ -8,12 +8,21 @@ class qa_html_theme_layer extends qa_html_theme_base
 {
 	private $cssopt = 'markdown_editor_css';
 	private $hljsopt = 'markdown_highlightjs';
+	private $allowed_template_opt = 'markdown_editor_allowed_template';
 
 	public function head_custom()
 	{
 		parent::head_custom();
 
-		$tmpl = array('ask', 'question');
+		$allowed_tmpl = qa_opt( $this->allowed_template_opt );
+
+		if ( strlen( $allowed_tmpl ) ) {
+			$tmpl = explode( ',', $allowed_tmpl );
+		} else {
+			//fall back for the defaults if the option is not set from the admin panel
+			$tmpl = array( 'ask', 'question' );
+		}
+
 		if (!in_array($this->template, $tmpl))
 			return;
 

--- a/qa-md-layer.php
+++ b/qa-md-layer.php
@@ -8,13 +8,13 @@ class qa_html_theme_layer extends qa_html_theme_base
 {
 	private $cssopt = 'markdown_editor_css';
 	private $hljsopt = 'markdown_highlightjs';
-	private $allowed_template_opt = 'markdown_editor_allowed_template';
+	private $allowed_templates_opt = 'markdown_editor_allowed_templates';
 
 	public function head_custom()
 	{
 		parent::head_custom();
 
-		$allowed_tmpl = qa_opt( $this->allowed_template_opt );
+		$allowed_tmpl = qa_opt( $this->allowed_templates_opt );
 
 		if ( strlen( $allowed_tmpl ) ) {
 			$tmpl = explode( ',', $allowed_tmpl );


### PR DESCRIPTION
First of all thank you for this great plugin . 

In the current version of MDEditor plugin only renders on the ask and question pages . But it does not work with the other plugins which are trying to use markdown editor on a specific page . 

Basically it is controlled by the code in the layer 

```
$tmpl = array( 'ask', 'question' );
if (!in_array($this->template, $tmpl))
            return;
```

In the pull request I made the feature bit more flexible , where an field is added called "allowed templates" and by default set to "questions,ask" and user can add the templates they want there so that the MD Editor can be rendered on those plugin pages too . 
